### PR TITLE
Add Openings collection (CMS + Join page)

### DIFF
--- a/src/content/openings/msc-bsc-model-lakes.md
+++ b/src/content/openings/msc-bsc-model-lakes.md
@@ -1,0 +1,17 @@
+---
+title: 'MSc Thesis / BSc Project: Model Discovery in Data & Model Lakes'
+type: MSc Thesis
+status: open
+pillars:
+  - AI in Data & Model Lakes
+order: 3
+links:
+  contact: R.Hai@tudelft.nl
+---
+
+How do you find the right model — or the right dataset — inside a lake of thousands? This project
+explores discovery, ranking, and reuse across heterogeneous data and rich model zoos.
+
+Scopable as either an MSc thesis or a more focused BSc research project. You will work with real model
+metadata and design search and recommendation methods that bring data integration and machine
+learning together.

--- a/src/content/openings/msc-federated-synthetic-data.md
+++ b/src/content/openings/msc-federated-synthetic-data.md
@@ -1,0 +1,19 @@
+---
+title: 'MSc Thesis: Synthetic Data Generation across Federated Silos'
+type: MSc Thesis
+status: open
+pillars:
+  - Federated & Private Learning
+order: 2
+links:
+  contact: R.Hai@tudelft.nl
+---
+
+Build on our work on cross-silo synthetic data (SiloFuse) to generate high-fidelity tabular data
+across organisations that never share their raw records.
+
+You will investigate latent diffusion models, privacy guarantees, and evaluation metrics for
+feature-partitioned data. A good fit for a TU Delft MSc student with a background in machine learning
+who enjoys both theory and building real systems.
+
+Rolling start — reach out any time with your interests and we'll shape a topic together.

--- a/src/content/openings/phd-quantum-data-management.md
+++ b/src/content/openings/phd-quantum-data-management.md
@@ -1,0 +1,23 @@
+---
+title: 'PhD Position: Quantum Algorithms for Data Management'
+type: PhD
+status: open
+pillars:
+  - Quantum Data Management
+deadline: 2026-09-30
+order: 1
+featured: true
+links:
+  apply: https://www.tudelft.nl/over-tu-delft/werken-bij-tu-delft/vacatures
+  contact: R.Hai@tudelft.nl
+---
+
+A fully funded 4-year PhD position exploring how NISQ-era quantum processors can accelerate core
+data-management tasks — query optimisation, entity matching, and anomaly detection.
+
+**You will** design and benchmark hybrid quantum–classical algorithms, and help shape a new research
+agenda at the intersection of databases and quantum computing.
+
+**We are looking for** an MSc in Computer Science, Physics, or a related field, strong programming
+skills, and a genuine curiosity about quantum computing. Prior quantum experience is a plus but not
+required.

--- a/src/lib/content/index.ts
+++ b/src/lib/content/index.ts
@@ -1,5 +1,5 @@
 import type { Component } from 'svelte';
-import type { Person, Project, Publication, BlogPost, EventItem } from './types';
+import type { Person, Project, Publication, BlogPost, EventItem, Opening } from './types';
 
 export interface Entry<T> {
 	slug: string;
@@ -46,6 +46,11 @@ export function getEvents(): Entry<EventItem>[] {
 	return toEntries<EventItem>(mods).sort(
 		(a, b) => +new Date(b.meta.startDate) - +new Date(a.meta.startDate)
 	);
+}
+
+export function getOpenings(): Entry<Opening>[] {
+	const mods = import.meta.glob('/src/content/openings/*.md', { eager: true }) as Record<string, Mod<Opening>>;
+	return toEntries<Opening>(mods).sort((a, b) => (a.meta.order ?? 99) - (b.meta.order ?? 99));
 }
 
 export const bySlug = <T>(entries: Entry<T>[], slug: string): Entry<T> | undefined =>

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -85,3 +85,26 @@ export interface EventItem {
 	};
 	featured?: boolean;
 }
+
+export type OpeningType =
+	| 'PhD'
+	| 'Postdoc'
+	| 'MSc Thesis'
+	| 'MSc Project'
+	| 'BSc Project'
+	| 'Internship'
+	| 'Other';
+
+export interface Opening {
+	title: string;
+	type?: OpeningType;
+	status?: 'open' | 'closed';
+	pillars?: string[];
+	deadline?: string;
+	links?: {
+		apply?: string;
+		contact?: string;
+	};
+	featured?: boolean;
+	order?: number;
+}

--- a/src/routes/join/+page.svelte
+++ b/src/routes/join/+page.svelte
@@ -1,13 +1,20 @@
 <script lang="ts">
 	import Seo from '$lib/components/Seo.svelte';
+	import Prose from '$lib/components/Prose.svelte';
+	import { getOpenings } from '$lib/content';
 	import { site } from '$lib/config';
-	import { IconMail, IconCheck } from '@tabler/icons-svelte';
+	import { IconMail, IconCheck, IconArrowUpRight, IconCalendar } from '@tabler/icons-svelte';
 
 	const looks = [
 		'A solid foundation in databases, systems, or machine learning',
 		'Strong programming skills and a taste for building real systems',
 		'Curiosity about where data management, AI, and quantum meet'
 	];
+
+	// Closed openings stay in the repo for the record but drop off the public page.
+	const openings = getOpenings().filter((o) => o.meta.status !== 'closed');
+	const fmt = (d: string) =>
+		new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
 </script>
 
 <Seo title="Join us" description="Open PhD, MSc, and postdoc opportunities at Infinidata Lab, TU Delft." />
@@ -19,6 +26,51 @@
 		<p>We're always interested in motivated students and researchers who want to shape the next generation of data systems.</p>
 	</div>
 </header>
+
+<section class="container openings">
+	<div class="op-head">
+		<h2>Current openings</h2>
+		{#if openings.length}<span class="op-count">{openings.length}</span>{/if}
+	</div>
+
+	{#if openings.length}
+		<div class="op-list">
+			{#each openings as o (o.slug)}
+				{@const Body = o.component}
+				<article class="op">
+					<div class="op-top">
+						<span class="op-type">{o.meta.type ?? 'Opening'}</span>
+						{#if o.meta.deadline}
+							<span class="op-deadline"><IconCalendar size={14} /> Apply by {fmt(o.meta.deadline)}</span>
+						{/if}
+					</div>
+					<h3>{o.meta.title}</h3>
+					{#if o.meta.pillars?.length}
+						<div class="tags">
+							{#each o.meta.pillars as p}<span class="tag">{p}</span>{/each}
+						</div>
+					{/if}
+					<Prose><Body /></Prose>
+					{#if o.meta.links?.apply || o.meta.links?.contact}
+						<div class="op-actions">
+							{#if o.meta.links?.apply}
+								<a class="btn btn-primary btn-sm" href={o.meta.links.apply} target="_blank" rel="noreferrer">Apply / details <IconArrowUpRight size={15} /></a>
+							{/if}
+							{#if o.meta.links?.contact}
+								<a class="btn btn-ghost btn-sm" href="mailto:{o.meta.links.contact}"><IconMail size={15} /> Enquire</a>
+							{/if}
+						</div>
+					{/if}
+				</article>
+			{/each}
+		</div>
+	{:else}
+		<p class="op-empty">
+			No specific openings are listed right now — but we always welcome strong open applications.
+			If our research fits your interests, email {site.pi} and we'll find a topic together.
+		</p>
+	{/if}
+</section>
 
 <div class="container">
 	<div class="join-grid">
@@ -47,6 +99,86 @@
 </div>
 
 <style>
+	.openings {
+		padding: 44px 0 4px;
+	}
+	.op-head {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		margin-bottom: 22px;
+	}
+	.op-head h2 {
+		font-size: 24px;
+	}
+	.op-count {
+		font-family: var(--font-mono);
+		font-size: 13px;
+		color: var(--faint);
+		background: var(--surface-2);
+		padding: 2px 10px;
+		border-radius: 999px;
+	}
+	.op-list {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+	.op {
+		background: var(--surface);
+		border: 1px solid var(--line);
+		border-radius: var(--radius-lg);
+		padding: 24px 26px;
+	}
+	.op-top {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 14px;
+		flex-wrap: wrap;
+		margin-bottom: 12px;
+	}
+	.op-type {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		font-weight: 500;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--brand-2);
+		background: color-mix(in srgb, var(--brand-2) 13%, transparent);
+		border: 1px solid color-mix(in srgb, var(--brand-2) 28%, transparent);
+		padding: 4px 11px;
+		border-radius: 999px;
+	}
+	.op-deadline {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		font-family: var(--font-mono);
+		font-size: 13px;
+		color: var(--muted);
+	}
+	.op h3 {
+		font-size: 21px;
+		margin-bottom: 12px;
+	}
+	.op .tags {
+		margin-bottom: 14px;
+	}
+	.op-actions {
+		display: flex;
+		gap: 12px;
+		flex-wrap: wrap;
+		margin-top: 18px;
+	}
+	.op-empty {
+		color: var(--muted);
+		background: var(--surface);
+		border: 1px dashed var(--line-2);
+		border-radius: var(--radius-lg);
+		padding: 28px;
+	}
+
 	.join-grid {
 		display: grid;
 		grid-template-columns: 1.6fr 1fr;

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -191,3 +191,49 @@ collections:
           - { name: recording, label: Recording, widget: string, required: false }
           - { name: external, label: External page, widget: string, required: false }
       - { name: body, label: Description, widget: markdown, required: false }
+
+  - name: openings
+    label: Openings
+    label_singular: Opening
+    folder: src/content/openings
+    create: true
+    identifier_field: title
+    slug: '{{slug}}'
+    summary: '{{title}} — {{fields.type}}'
+    sortable_fields: [order, deadline, title]
+    fields:
+      - { name: title, label: Title, widget: string, hint: 'e.g. MSc Thesis: …, PhD Position: …' }
+      - name: type
+        label: Type
+        widget: select
+        default: MSc Thesis
+        options:
+          - PhD
+          - Postdoc
+          - MSc Thesis
+          - MSc Project
+          - BSc Project
+          - Internship
+          - Other
+      - { name: status, label: Status, widget: select, options: [open, closed], default: open, hint: 'Closed openings are hidden from the site' }
+      - name: pillars
+        label: Research pillars
+        widget: select
+        multiple: true
+        required: false
+        options:
+          - AI in Data & Model Lakes
+          - Federated & Private Learning
+          - Quantum Data Management
+      - { name: deadline, label: Application deadline, widget: datetime, required: false, format: 'YYYY-MM-DD', date_format: 'YYYY-MM-DD', time_format: false, hint: 'Leave empty for rolling / open-ended' }
+      - { name: order, label: Sort order, widget: number, required: false, value_type: int }
+      - { name: featured, label: Featured, widget: boolean, required: false, default: false }
+      - name: links
+        label: Links
+        widget: object
+        required: false
+        collapsed: true
+        fields:
+          - { name: apply, label: Apply / vacancy URL, widget: string, required: false }
+          - { name: contact, label: Contact email, widget: string, required: false }
+      - { name: body, label: Description, widget: markdown }


### PR DESCRIPTION
## What

Adds a general-purpose, CMS-managed **Openings** content type so the lab can post recruiting opportunities through Sveltia CMS without touching code. Deliberately broad — covers PhD/postdoc positions, MSc theses, MSc/BSc projects, internships, and an "Other" escape hatch.

## Changes

- **Type** — `Opening` + `OpeningType` union in `src/lib/content/types.ts`
- **Loader** — `getOpenings()` in `src/lib/content/index.ts` (sorted by `order`)
- **CMS** — `openings` collection in `static/admin/config.yml` (shows up in the Sveltia sidebar)
- **Content** — `src/content/openings/` with 3 sample entries, one per research pillar
- **Page** — `/join` gains a dynamic "Current openings" section; the existing "Who we're looking for" / "How to apply" content is untouched

## Content model

`type` (select) · `status` (open/closed — closed entries auto-hide from the site) · `pillars` (multi-select) · `deadline` (optional; blank = rolling) · `links.apply` / `links.contact` · Markdown `body`.

## Behavior

- Each opening renders as a card: type badge, deadline, pillar tags, rendered body, and Apply/Enquire buttons that only appear when those links exist.
- Empty state (no open openings) falls back to an "open applications welcome" note, so the page never looks broken.
- Wired into existing IA — the nav "Join us" button and homepage CTA already point at `/join`, so no new nav entry was added.

## Verification

- `npm run check` — no new type errors (the pre-existing errors in `vite.config.ts` / blog / events are unrelated)
- `npm run build` — passes
- Rendered `/join` in the browser; all three openings display correctly with no console errors

## Notes for reviewer

- The 3 sample openings are realistic placeholders — edit or delete them via the CMS.
- Scope is intentionally limited to the Openings feature: this does **not** include deployment wiring (GitHub Actions / Cloudflare auth worker) or the separately-tracked `Role`/`BSc` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
