### PR TITLE
Content overhaul: two research directions, full publications, venue b…

### DIFF
--- a/src/content/openings/msc-bsc-model-lakes.md
+++ b/src/content/openings/msc-bsc-model-lakes.md
@@ -1,9 +1,9 @@
 ---
-title: 'MSc Thesis / BSc Project: Model Discovery in Data & Model Lakes'
+title: 'MSc Thesis / BSc Project: Model Discovery in Data Lakes'
 type: MSc Thesis
 status: open
 pillars:
-  - AI in Data & Model Lakes
+  - AI in Data Lakes
 order: 3
 links:
   contact: R.Hai@tudelft.nl

--- a/src/content/openings/msc-federated-synthetic-data.md
+++ b/src/content/openings/msc-federated-synthetic-data.md
@@ -3,7 +3,7 @@ title: 'MSc Thesis: Synthetic Data Generation across Federated Silos'
 type: MSc Thesis
 status: open
 pillars:
-  - Federated & Private Learning
+  - AI in Data Lakes
 order: 2
 links:
   contact: R.Hai@tudelft.nl

--- a/src/content/projects/amalur.md
+++ b/src/content/projects/amalur.md
@@ -5,7 +5,7 @@ status: active
 order: 1
 featured: true
 pillars:
-  - AI in Data & Model Lakes
+  - AI in Data Lakes
 tags:
   - Data integration
   - Machine learning

--- a/src/content/projects/silofuse.md
+++ b/src/content/projects/silofuse.md
@@ -5,7 +5,7 @@ status: active
 order: 2
 featured: true
 pillars:
-  - Federated & Private Learning
+  - AI in Data Lakes
 tags:
   - Diffusion
   - Privacy

--- a/src/content/projects/transql.md
+++ b/src/content/projects/transql.md
@@ -5,7 +5,7 @@ status: active
 order: 4
 featured: true
 pillars:
-  - AI in Data & Model Lakes
+  - AI in Data Lakes
 tags:
   - LLM serving
   - SQL

--- a/src/content/projects/wavestitch.md
+++ b/src/content/projects/wavestitch.md
@@ -5,7 +5,7 @@ status: active
 order: 3
 featured: true
 pillars:
-  - Federated & Private Learning
+  - AI in Data Lakes
 tags:
   - Diffusion
   - Generative

--- a/src/content/publications/accelerating-ml-queries.md
+++ b/src/content/publications/accelerating-ml-queries.md
@@ -1,0 +1,17 @@
+---
+title: 'Accelerating machine learning queries with linear algebra query processing'
+authors:
+  - Wenbo Sun
+  - Asterios Katsifodimos
+  - Rihan Hai
+year: 2025
+venue: DAPD
+type: journal
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1007/s10619-024-07451-7
+  arxiv: https://arxiv.org/abs/2306.08367
+---
+
+Speeding up machine-learning inference queries by expressing them as linear-algebra operations inside the query processor.

--- a/src/content/publications/amalur-cidr.md
+++ b/src/content/publications/amalur-cidr.md
@@ -1,0 +1,17 @@
+---
+title: 'Amalur: Next-generation Data Integration in Data Lakes'
+authors:
+  - Rihan Hai
+  - Christos Koutras
+  - Andra Ionescu
+  - Asterios Katsifodimos
+year: 2022
+venue: CIDR
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  pdf: https://vldb.org/cidrdb/2022/amalur-next-generation-data-integration-in-data-lakes.html
+---
+
+The vision for Amalur — next-generation data integration that treats the data lake as the substrate for machine learning.

--- a/src/content/publications/amalur-data-integration-ml.md
+++ b/src/content/publications/amalur-data-integration-ml.md
@@ -1,0 +1,21 @@
+---
+title: 'Amalur: Data Integration Meets Machine Learning'
+authors:
+  - Rihan Hai
+  - Christos Koutras
+  - Andra Ionescu
+  - Ziyu Li
+  - Wenbo Sun
+  - Jessie van Schijndel
+  - Yan Kang
+  - Asterios Katsifodimos
+year: 2023
+venue: ICDE
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/ICDE55515.2023.00301
+---
+
+The first full Amalur paper, bringing data integration and machine learning together over data lakes.

--- a/src/content/publications/amalur.md
+++ b/src/content/publications/amalur.md
@@ -4,15 +4,17 @@ authors:
   - Ziyu Li
   - Wenbo Sun
   - Danning Zhan
-  - Yujia Kang
-  - Asterios Katsifodimos
+  - Yan Kang
+  - Lydia Y. Chen
+  - Alessandro Bozzon
   - Rihan Hai
 year: 2024
 venue: IEEE TKDE
 type: journal
 pillars:
-  - AI in Data & Model Lakes
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/TKDE.2024.3357389
 ---
 
-A full design unifying data integration and machine learning over data lakes, automating the path
-from scattered sources to trained models.
+A full design unifying data integration and machine learning over data lakes, automating the path from scattered sources to trained models.

--- a/src/content/publications/autofeat.md
+++ b/src/content/publications/autofeat.md
@@ -1,0 +1,18 @@
+---
+title: 'AutoFeat: Transitive Feature Discovery over Join Paths'
+authors:
+  - Andra Ionescu
+  - Kiril Vasilev
+  - Florena Buse
+  - Rihan Hai
+  - Asterios Katsifodimos
+year: 2024
+venue: ICDE
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/ICDE60146.2024.00150
+---
+
+Automatically discovering predictive features transitively across join paths to enrich training data.

--- a/src/content/publications/cebench.md
+++ b/src/content/publications/cebench.md
@@ -1,0 +1,19 @@
+---
+title: 'CEBench: A Benchmarking Toolkit for the Cost-Effectiveness of LLM Pipelines'
+authors:
+  - Wenbo Sun
+  - Jiaqi Wang
+  - Qiming Guo
+  - Ziyu Li
+  - Wenlu Wang
+  - Rihan Hai
+year: 2024
+venue: arXiv
+type: preprint
+pillars:
+  - AI in Data Lakes
+links:
+  arxiv: https://arxiv.org/abs/2407.12797
+---
+
+A benchmarking toolkit for measuring the cost-effectiveness of large-language-model pipelines.

--- a/src/content/publications/cross-source-ml-training.md
+++ b/src/content/publications/cross-source-ml-training.md
@@ -1,0 +1,15 @@
+---
+title: 'Cross-Source ML Model Training'
+authors:
+  - Wenbo Sun
+  - Rihan Hai
+year: 2024
+venue: ICDE
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/ICDE60146.2024.00464
+---
+
+Training machine-learning models directly across multiple data sources without first materialising one integrated table.

--- a/src/content/publications/data-lakes-survey.md
+++ b/src/content/publications/data-lakes-survey.md
@@ -1,0 +1,17 @@
+---
+title: 'Data Lakes: A Survey of Functions and Systems'
+authors:
+  - Rihan Hai
+  - Christos Koutras
+  - Christoph Quix
+  - Matthias Jarke
+year: 2023
+venue: IEEE TKDE
+type: journal
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/ICDE60146.2024.00471
+---
+
+A comprehensive survey of data-lake functions and systems, charting the design space of modern data lakes.

--- a/src/content/publications/database-as-runtime.md
+++ b/src/content/publications/database-as-runtime.md
@@ -1,0 +1,16 @@
+---
+title: 'Database as Runtime: Compiling LLMs to SQL for In-database Model Serving'
+authors:
+  - Wenbo Sun
+  - Ziyu Li
+  - Rihan Hai
+year: 2025
+venue: SIGMOD
+type: demo
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1145/3722212.3725093
+---
+
+A demo that compiles large language models to SQL so inference runs inside the database, with no external serving stack.

--- a/src/content/publications/database-is-all-you-need.md
+++ b/src/content/publications/database-is-all-you-need.md
@@ -9,7 +9,9 @@ year: 2025
 venue: EDBT
 type: conference
 pillars:
-  - AI in Data & Model Lakes
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.48786/edbt.2025.103
 ---
 
 Showing how relational query engines can serve large language model workloads end to end.

--- a/src/content/publications/harpoon.md
+++ b/src/content/publications/harpoon.md
@@ -1,0 +1,17 @@
+---
+title: 'Harpoon: Generalised Manifold Guidance for Conditional Tabular Diffusion'
+authors:
+  - Aditya Shankar
+  - Yuandou Wang
+  - Rihan Hai
+  - Lydia Y. Chen
+year: 2026
+venue: arXiv
+type: preprint
+pillars:
+  - AI in Data Lakes
+links:
+  arxiv: https://arxiv.org/abs/2602.07875
+---
+
+Generalised manifold guidance for steering conditional tabular diffusion models toward higher-fidelity synthetic data.

--- a/src/content/publications/human-in-the-loop-feature-discovery.md
+++ b/src/content/publications/human-in-the-loop-feature-discovery.md
@@ -1,0 +1,18 @@
+---
+title: 'Human-in-the-Loop Feature Discovery for Tabular Data'
+authors:
+  - Andra Ionescu
+  - Zeger Mouw
+  - Efthimia Aivaloglou
+  - Rihan Hai
+  - Asterios Katsifodimos
+year: 2024
+venue: CIKM
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1145/3627673.3679211
+---
+
+Bringing the analyst into the loop to discover and select useful features for tabular machine learning.

--- a/src/content/publications/ilargi.md
+++ b/src/content/publications/ilargi.md
@@ -1,0 +1,16 @@
+---
+title: 'Ilargi: A GPU Compatible Factorized ML Model Training Framework'
+authors:
+  - Wenbo Sun
+  - Rihan Hai
+year: 2025
+venue: WISE
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1007/978-981-95-7394-3_2
+  arxiv: https://arxiv.org/abs/2502.01985
+---
+
+A GPU-compatible framework for factorised machine-learning model training directly over joined relational data.

--- a/src/content/publications/imlp-continual-learning.md
+++ b/src/content/publications/imlp-continual-learning.md
@@ -1,0 +1,16 @@
+---
+title: 'IMLP: An Energy-Efficient Continual Learning Method for Tabular Data Streams'
+authors:
+  - Yuandou Wang
+  - Filip Gunnarsson
+  - Rihan Hai
+year: 2025
+venue: arXiv
+type: preprint
+pillars:
+  - AI in Data Lakes
+links:
+  arxiv: https://arxiv.org/abs/2510.04660
+---
+
+An energy-efficient continual-learning method for streaming tabular data, built on an attention-based feature memory.

--- a/src/content/publications/llm-pqa.md
+++ b/src/content/publications/llm-pqa.md
@@ -1,0 +1,18 @@
+---
+title: 'LLM-PQA: LLM-enhanced Prediction Query Answering'
+authors:
+  - Ziyu Li
+  - Wenjie Zhao
+  - Asterios Katsifodimos
+  - Rihan Hai
+year: 2024
+venue: CIKM
+type: demo
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1145/3627673.3679210
+  arxiv: https://arxiv.org/abs/2409.01140
+---
+
+A demo that answers prediction queries by combining large language models with in-database machine learning.

--- a/src/content/publications/macaroni.md
+++ b/src/content/publications/macaroni.md
@@ -1,0 +1,18 @@
+---
+title: 'Macaroni: Crawling and Enriching Metadata from Public Model Zoos'
+authors:
+  - Ziyu Li
+  - Henk Kant
+  - Rihan Hai
+  - Asterios Katsifodimos
+  - Alessandro Bozzon
+year: 2023
+venue: ICWE
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1007/978-3-031-34444-2_31
+---
+
+Crawling and enriching metadata from public model zoos to make pre-trained models searchable.

--- a/src/content/publications/metadata-representations.md
+++ b/src/content/publications/metadata-representations.md
@@ -1,0 +1,19 @@
+---
+title: 'Metadata Representations for Queryable Repositories of Machine Learning Models'
+authors:
+  - Ziyu Li
+  - Henk Kant
+  - Rihan Hai
+  - Asterios Katsifodimos
+  - Marco Brambilla
+  - Alessandro Bozzon
+year: 2023
+venue: IEEE Access
+type: journal
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/ACCESS.2023.3330647
+---
+
+Metadata representations that make repositories of machine-learning models queryable and discoverable.

--- a/src/content/publications/model-selection-model-zoo.md
+++ b/src/content/publications/model-selection-model-zoo.md
@@ -1,5 +1,5 @@
 ---
-title: Model Selection with Model Zoo via Graph Learning
+title: 'Model Selection with Model Zoo via Graph Learning'
 authors:
   - Ziyu Li
   - Hilco van der Wilk
@@ -11,8 +11,10 @@ year: 2024
 venue: ICDE
 type: conference
 pillars:
-  - AI in Data & Model Lakes
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/ICDE60146.2024.00088
+  arxiv: https://arxiv.org/abs/2404.03988
 ---
 
-Selecting the best pre-trained model from a large model zoo by framing the problem as graph
-learning.
+Selecting the best pre-trained model from a large model zoo by framing the problem as graph learning.

--- a/src/content/publications/optimizing-ml-inference.md
+++ b/src/content/publications/optimizing-ml-inference.md
@@ -1,0 +1,20 @@
+---
+title: 'Optimizing ML Inference Queries Under Constraints'
+authors:
+  - Ziyu Li
+  - Mariette Schönfeld
+  - Wenbo Sun
+  - Marios Fragkoulis
+  - Rihan Hai
+  - Alessandro Bozzon
+  - Asterios Katsifodimos
+year: 2023
+venue: ICWE
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1007/978-3-031-34444-2_4
+---
+
+Optimising machine-learning inference queries under accuracy and resource constraints.

--- a/src/content/publications/private-quantum-database.md
+++ b/src/content/publications/private-quantum-database.md
@@ -1,0 +1,16 @@
+---
+title: 'Private Quantum Database'
+authors:
+  - Giancarlo Gatti
+  - Floris Geerts
+  - Rihan Hai
+year: 2025
+venue: arXiv
+type: preprint
+pillars:
+  - Quantum Data Management
+links:
+  arxiv: https://arxiv.org/abs/2508.19055
+---
+
+Protocols for querying a database held on a quantum computer while keeping the query itself private.

--- a/src/content/publications/qc-meet-cq.md
+++ b/src/content/publications/qc-meet-cq.md
@@ -1,0 +1,15 @@
+---
+title: 'QC meet CQ: Quantum Conjunctive Queries'
+authors:
+  - Floris Geerts
+  - Rihan Hai
+year: 2025
+venue: SIGMOD Workshop
+type: workshop
+pillars:
+  - Quantum Data Management
+links:
+  doi: https://doi.org/10.1145/3736393.3736696
+---
+
+Casting conjunctive queries as quantum computations, linking database query evaluation with quantum circuits.

--- a/src/content/publications/quadratic-sums-of-powers.md
+++ b/src/content/publications/quadratic-sums-of-powers.md
@@ -1,0 +1,19 @@
+---
+title: 'Quadratic Sums-of-Powers for Fixed-Parameter Tractable Quantum-Circuit Simulation'
+authors:
+  - Alexis de Colnet
+  - Floris Geerts
+  - Rihan Hai
+  - Alfons Laarman
+  - Joon Hyung Lee
+  - Guillermo A. Pérez
+year: 2026
+venue: arXiv
+type: preprint
+pillars:
+  - Quantum Data Management
+links:
+  arxiv: https://arxiv.org/abs/2605.29944
+---
+
+A fixed-parameter tractable method for classically simulating quantum circuits via a sums-of-powers representation.

--- a/src/content/publications/quantum-data-nisq.md
+++ b/src/content/publications/quantum-data-nisq.md
@@ -1,5 +1,5 @@
 ---
-title: Quantum Data Management in the NISQ Era
+title: 'Quantum Data Management in the NISQ Era'
 authors:
   - Rihan Hai
   - Shih-Han Hung
@@ -11,7 +11,8 @@ venue: PVLDB
 type: journal
 pillars:
   - Quantum Data Management
+links:
+  doi: https://doi.org/10.14778/3725688.3725701
 ---
 
-A vision and systems perspective on managing data for quantum computing in the noisy
-intermediate-scale quantum (NISQ) era.
+A vision and systems perspective on managing data for quantum computing in the noisy intermediate-scale quantum (NISQ) era.

--- a/src/content/publications/quantum-data-structures.md
+++ b/src/content/publications/quantum-data-structures.md
@@ -1,0 +1,16 @@
+---
+title: 'Quantum Data Structures for Enhanced Database Performance'
+authors:
+  - Tim Littau
+  - Ziyu Li
+  - Rihan Hai
+year: 2024
+venue: VLDB Workshop
+type: workshop
+pillars:
+  - Quantum Data Management
+links:
+  pdf: https://vldb.org/workshops/2024/proceedings/QDSM/QDSM.6.pdf
+---
+
+Exploring how quantum data structures could accelerate core database operations.

--- a/src/content/publications/quantum-theory-to-opportunities.md
+++ b/src/content/publications/quantum-theory-to-opportunities.md
@@ -1,0 +1,17 @@
+---
+title: 'Quantum Data Management: From Theory to Opportunities'
+authors:
+  - Rihan Hai
+  - Shih-Han Hung
+  - Sebastian Feld
+year: 2024
+venue: ICDE
+type: conference
+pillars:
+  - Quantum Data Management
+links:
+  doi: https://doi.org/10.1109/ICDE60146.2024.00410
+  arxiv: https://arxiv.org/abs/2403.02856
+---
+
+A tutorial mapping the emerging research agenda where data management meets quantum computing.

--- a/src/content/publications/qymera.md
+++ b/src/content/publications/qymera.md
@@ -4,12 +4,13 @@ authors:
   - Tim Littau
   - Rihan Hai
 year: 2025
-venue: SIGMOD (Demo)
+venue: SIGMOD
 type: demo
 pillars:
   - Quantum Data Management
-award: ''
+links:
+  doi: https://doi.org/10.1145/3722212.3725126
+  arxiv: https://arxiv.org/abs/2506.08759
 ---
 
-A demonstration of simulating quantum circuits directly inside a relational database management
-system.
+A demonstration of simulating quantum circuits directly inside a relational database management system.

--- a/src/content/publications/share-secrets-vfl.md
+++ b/src/content/publications/share-secrets-vfl.md
@@ -1,0 +1,18 @@
+---
+title: 'Share Secrets for Privacy: Confidential Forecasting with Vertical Federated Learning'
+authors:
+  - Aditya Shankar
+  - Jérémie Decouchant
+  - Dimitra Gkorou
+  - Rihan Hai
+  - Lydia Y. Chen
+year: 2025
+venue: ARES
+type: conference
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1007/978-3-032-00624-0_18
+---
+
+Confidential time-series forecasting across vertically partitioned data using secret sharing and vertical federated learning.

--- a/src/content/publications/silofuse.md
+++ b/src/content/publications/silofuse.md
@@ -4,13 +4,14 @@ authors:
   - Aditya Shankar
   - Hans Brouwer
   - Rihan Hai
-  - Lydia Chen
+  - Lydia Y. Chen
 year: 2024
 venue: ICDE
 type: conference
 pillars:
-  - Federated & Private Learning
+  - AI in Data Lakes
+links:
+  arxiv: https://arxiv.org/abs/2404.03299
 ---
 
-Generating synthetic tabular data across feature-partitioned silos using latent diffusion, without
-sharing raw records.
+Generating synthetic tabular data across feature-partitioned silos using latent diffusion, without sharing raw records.

--- a/src/content/publications/transql.md
+++ b/src/content/publications/transql.md
@@ -1,16 +1,17 @@
 ---
-title: 'TranSQL+: Serving Large Language Models with SQL on Low-Resource Hardware'
+title: 'TranSQL +: Serving Large Language Models with SQL on Low-Resource Hardware'
 authors:
   - Wenbo Sun
   - Qiming Guo
-  - Rihan Hai
   - Wenlu Wang
+  - Rihan Hai
 year: 2025
 venue: SIGMOD
 type: conference
 pillars:
-  - AI in Data & Model Lakes
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1145/3769836
 ---
 
-Compiling large language model inference into relational queries so models can be served from
-within a database engine on modest hardware.
+Compiling large language model inference into relational queries so models can be served from within a database engine on modest hardware.

--- a/src/content/publications/wavestitch.md
+++ b/src/content/publications/wavestitch.md
@@ -1,16 +1,18 @@
 ---
-title: 'WaveStitch: Flexible & Fast Conditional Time-Series Generation with Diffusion Models'
+title: 'WaveStitch: Flexible and Fast Conditional Time Series Generation With Diffusion Models'
 authors:
   - Aditya Shankar
-  - Rihan Hai
   - Lydia Y. Chen
   - Arie van Deursen
+  - Rihan Hai
 year: 2025
 venue: SIGMOD
 type: conference
 pillars:
-  - Federated & Private Learning
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1145/3769842
+  arxiv: https://arxiv.org/abs/2503.06231
 ---
 
-A diffusion-based method for fast, controllable generation of realistic time-series data under
-user-specified conditions.
+A diffusion-based method for fast, controllable generation of realistic time-series data under user-specified conditions.

--- a/src/content/publications/will-sharing-metadata-leak-privacy.md
+++ b/src/content/publications/will-sharing-metadata-leak-privacy.md
@@ -1,0 +1,15 @@
+---
+title: 'Will Sharing Metadata Leak Privacy?'
+authors:
+  - Danning Zhan
+  - Rihan Hai
+year: 2024
+venue: ICDEW
+type: workshop
+pillars:
+  - AI in Data Lakes
+links:
+  doi: https://doi.org/10.1109/ICDEW61823.2024.00047
+---
+
+Studying whether sharing dataset metadata for discovery can inadvertently leak private information.

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -15,9 +15,8 @@
 			</div>
 			<div>
 				<h5>Research</h5>
-				<a href="/research">Data &amp; Model Lakes</a>
-				<a href="/research">Federated Learning</a>
-				<a href="/research">Quantum Data</a>
+				<a href="/research">AI in Data Lakes</a>
+				<a href="/research">Quantum Data Management</a>
 			</div>
 			<div>
 				<h5>Explore</h5>

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Entry } from '$lib/content';
 	import type { Project } from '$lib/content/types';
+	import VenueBadge from '$lib/components/VenueBadge.svelte';
 	import {
 		IconFileText,
 		IconBrandGithub,
@@ -21,7 +22,7 @@
 
 	{#if p.venue || p.award || p.tags?.length}
 		<div class="tags">
-			{#if p.venue}<span class="tag venue">{p.venue}</span>{/if}
+			{#if p.venue}<VenueBadge venue={p.venue} />{/if}
 			{#if p.award}<span class="tag award">{p.award}</span>{/if}
 			{#each p.tags ?? [] as t}<span class="tag">{t}</span>{/each}
 		</div>

--- a/src/lib/components/PublicationItem.svelte
+++ b/src/lib/components/PublicationItem.svelte
@@ -2,6 +2,7 @@
 	import type { Entry } from '$lib/content';
 	import type { Publication } from '$lib/content/types';
 	import { internalAuthors } from '$lib/config';
+	import VenueBadge from '$lib/components/VenueBadge.svelte';
 	import {
 		IconFileText,
 		IconLink,
@@ -23,7 +24,7 @@
 		{#each p.authors as a, i}<span class:me={internalAuthors.includes(a)}>{a}</span>{#if i < p.authors.length - 1}<span class="sep">, </span>{/if}{/each}
 	</p>
 	<div class="pub-foot">
-		<span class="tag venue">{p.venue}{#if p.year}&nbsp;{p.year}{/if}</span>
+		<VenueBadge venue={p.venue} year={p.year} />
 		{#if p.award}<span class="tag award">{p.award}</span>{/if}
 		{#if p.links}
 			<span class="links">

--- a/src/lib/components/VenueBadge.svelte
+++ b/src/lib/components/VenueBadge.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	import { venueInfo } from '$lib/venues';
+	let { venue, year }: { venue: string; year?: number } = $props();
+	const v = venueInfo(venue);
+	const shownYear = year ?? v.year;
+</script>
+
+<span class="venue {v.group}" title={venue}>
+	{#if v.publisher}<span class="pub">{v.publisher}</span>{/if}
+	<span class="lbl">{v.label}</span>
+	{#if shownYear}<span class="yr">{shownYear}</span>{/if}
+</span>
+
+<style>
+	.venue {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 5px;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		font-weight: 600;
+		line-height: 1;
+		padding: 4px 9px;
+		border-radius: 6px;
+		white-space: nowrap;
+		color: var(--c);
+		border: 1px solid color-mix(in srgb, var(--c) 30%, transparent);
+		background: color-mix(in srgb, var(--c) 11%, transparent);
+	}
+	.pub {
+		font-size: 9px;
+		font-weight: 700;
+		letter-spacing: 0.07em;
+		text-transform: uppercase;
+		opacity: 0.7;
+	}
+	.yr {
+		font-weight: 450;
+		opacity: 0.65;
+	}
+
+	/* Publisher / community accent colours, tuned for light and dark themes. */
+	.acm {
+		--c: light-dark(#0a66c2, #5aa9ff);
+	}
+	.ieee {
+		--c: light-dark(#00629b, #56b3e6);
+	}
+	.vldb {
+		--c: light-dark(#b06f0e, #fbbf24);
+	}
+	.edbt {
+		--c: light-dark(#0f766e, #2dd4bf);
+	}
+	.cidr {
+		--c: light-dark(#475569, #9aa7bd);
+	}
+	.arxiv {
+		--c: light-dark(#b31b1b, #f87171);
+	}
+	.springer {
+		--c: light-dark(#6d28d9, #b79bfb);
+	}
+	.ares {
+		--c: light-dark(#9f1239, #fb7185);
+	}
+	.other {
+		--c: var(--brand-2);
+	}
+</style>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,7 +5,7 @@ export const site = {
 	name: 'Infinidata Lab',
 	tagline: 'Data management for the age of AI',
 	description:
-		'Infinidata Lab at TU Delft builds the next generation of data systems — uniting data lakes with machine learning, privacy-preserving federated learning, and quantum data management.',
+		'Infinidata Lab at TU Delft builds data systems for the age of AI and quantum computing — bringing machine learning to the data lake, and reinventing data management for quantum processors.',
 	institution: 'Delft University of Technology',
 	faculty: 'Faculty of EEMCS · Web Information Systems',
 	pi: 'Dr. Rihan Hai',

--- a/src/lib/venues.ts
+++ b/src/lib/venues.ts
@@ -1,0 +1,42 @@
+// Maps a venue string to a recognizable, publisher-branded badge.
+// `group` drives the accent colour (see VenueBadge.svelte); `publisher` is the
+// familiar umbrella brand (IEEE, ACM, …) shown as a small prefix where it helps.
+// Unknown venues fall back to a neutral badge, so nothing ever breaks.
+
+export interface VenueInfo {
+	label: string;
+	group: string;
+	publisher?: string;
+	year?: number;
+}
+
+const TABLE: { test: RegExp; label: string; group: string; publisher?: string }[] = [
+	{ test: /sigmod\s*workshop|q-?data/i, label: 'SIGMOD Workshop', group: 'acm', publisher: 'ACM' },
+	{ test: /sigmod/i, label: 'SIGMOD', group: 'acm', publisher: 'ACM' },
+	{ test: /cikm/i, label: 'CIKM', group: 'acm', publisher: 'ACM' },
+	{ test: /tkde|trans.*knowl/i, label: 'IEEE TKDE', group: 'ieee' },
+	{ test: /ieee\s*access/i, label: 'IEEE Access', group: 'ieee' },
+	{ test: /icdew/i, label: 'ICDEW', group: 'ieee', publisher: 'IEEE' },
+	{ test: /icde/i, label: 'ICDE', group: 'ieee', publisher: 'IEEE' },
+	{ test: /pvldb|vldb\s*endow/i, label: 'PVLDB', group: 'vldb' },
+	{ test: /vldb\s*workshop/i, label: 'VLDB Workshop', group: 'vldb' },
+	{ test: /cidr/i, label: 'CIDR', group: 'cidr' },
+	{ test: /edbt/i, label: 'EDBT', group: 'edbt' },
+	{ test: /arxiv|preprint|corr/i, label: 'arXiv', group: 'arxiv' },
+	{ test: /icwe|web\s*engineering/i, label: 'ICWE', group: 'springer', publisher: 'Springer' },
+	{ test: /wise/i, label: 'WISE', group: 'springer', publisher: 'Springer' },
+	{ test: /dapd|distributed.*parallel/i, label: 'DAPD', group: 'springer', publisher: 'Springer' },
+	{ test: /ares/i, label: 'ARES', group: 'ares' }
+];
+
+export function venueInfo(venue: string): VenueInfo {
+	const ym = venue.match(/\b(19|20)\d{2}\b/);
+	const year = ym ? Number(ym[0]) : undefined;
+	for (const row of TABLE) {
+		if (row.test.test(venue)) {
+			return { label: row.label, group: row.group, publisher: row.publisher, year };
+		}
+	}
+	// Unknown venue: keep the original text (minus any trailing year), neutral colour.
+	return { label: venue.replace(/\s*\b(19|20)\d{2}\b\s*/, ' ').trim(), group: 'other', year };
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 	import CtaBand from '$lib/components/CtaBand.svelte';
 	import { getProjects, getPublications, featured } from '$lib/content';
 	import { site } from '$lib/config';
-	import { IconArrowRight, IconStack2, IconShieldLock, IconAtom2 } from '@tabler/icons-svelte';
+	import { IconArrowRight, IconStack2, IconAtom2 } from '@tabler/icons-svelte';
 
 	const projects = featured(getProjects()).slice(0, 4);
 	const pubs = getPublications().slice(0, 3);
@@ -35,25 +35,22 @@
 		<div class="section-head">
 			<div>
 				<span class="eyebrow">What we work on</span>
-				<h2>Three research frontiers</h2>
-				<p>We rethink how data is integrated, shared, and processed — from the model lake to the quantum processor.</p>
+				<h2>Data systems, in two directions</h2>
+				<p>Everything we build is a data system. We push in two directions — making data systems work for AI, and inventing data systems for quantum computing.</p>
 			</div>
 		</div>
-		<div class="grid grid-3">
+		<div class="grid grid-2">
 			<div class="card">
 				<div class="ic"><IconStack2 size={24} /></div>
-				<h3>AI in Data &amp; Model Lakes</h3>
-				<p>Bringing data integration and machine learning together, so heterogeneous data and rich model zoos meet in one lake.</p>
-			</div>
-			<div class="card">
-				<div class="ic"><IconShieldLock size={24} /></div>
-				<h3>Federated &amp; Private Learning</h3>
-				<p>Training and synthetic-data generation across organisational silos — without ever sharing the raw data.</p>
+				<p class="tagline">Data Systems for AI</p>
+				<h3>AI in Data Lakes</h3>
+				<p>We bring machine learning to the data lake — integrating scattered data into training sets, discovering and serving models, and generating synthetic data across silos.</p>
 			</div>
 			<div class="card">
 				<div class="ic"><IconAtom2 size={24} /></div>
+				<p class="tagline">Data Systems for Quantum Computing</p>
 				<h3>Quantum Data Management</h3>
-				<p>Reimagining query optimisation, entity matching, and anomaly detection for the NISQ-era quantum processor.</p>
+				<p>We reinvent data management for quantum computers — simulating circuits inside a database, compiling quantum queries, and managing data in the NISQ era.</p>
 			</div>
 		</div>
 	</div>

--- a/src/routes/join/+page.svelte
+++ b/src/routes/join/+page.svelte
@@ -86,7 +86,7 @@
 			<p class="lede">Funded PhD and postdoc openings are posted on the TU Delft vacancies portal. If nothing is listed that fits, a short, well-argued email is still worth sending.</p>
 
 			<h2 class="mt">MSc thesis &amp; projects</h2>
-			<p class="lede">TU Delft MSc students can do a thesis or research project with us across all three research lines. Reach out with your interests and we'll find a topic together.</p>
+			<p class="lede">TU Delft MSc students can do a thesis or research project with us across both research directions. Reach out with your interests and we'll find a topic together.</p>
 		</div>
 
 		<aside class="apply">

--- a/src/routes/publications/+page.svelte
+++ b/src/routes/publications/+page.svelte
@@ -9,9 +9,11 @@
 	const pillars = [...new Set(all.flatMap((p) => p.meta.pillars ?? []))];
 	const filters = [
 		{ id: 'all', label: 'All' },
-		{ id: 'journal', label: 'Journal' },
 		{ id: 'conference', label: 'Conference' },
+		{ id: 'journal', label: 'Journal' },
+		{ id: 'workshop', label: 'Workshop' },
 		{ id: 'demo', label: 'Demo' },
+		{ id: 'preprint', label: 'Preprint' },
 		...pillars.map((p) => ({ id: 'pillar:' + p, label: p }))
 	];
 

--- a/src/routes/research/+page.svelte
+++ b/src/routes/research/+page.svelte
@@ -3,23 +3,20 @@
 	import ProjectCard from '$lib/components/ProjectCard.svelte';
 	import PublicationItem from '$lib/components/PublicationItem.svelte';
 	import { getProjects, getPublications } from '$lib/content';
-	import { IconStack2, IconShieldLock, IconAtom2 } from '@tabler/icons-svelte';
+	import { IconStack2, IconAtom2 } from '@tabler/icons-svelte';
 
 	const pillars = [
 		{
-			id: 'AI in Data & Model Lakes',
+			id: 'AI in Data Lakes',
+			kicker: 'Data Systems for AI',
 			icon: IconStack2,
-			blurb: 'We bring data integration and machine learning together — so heterogeneous data and rich model zoos meet in one lake, and serving models becomes a query.'
-		},
-		{
-			id: 'Federated & Private Learning',
-			icon: IconShieldLock,
-			blurb: 'We train models and generate synthetic data across organisational silos, extracting value from data without ever moving the raw records.'
+			blurb: 'We bring machine learning and data lakes together: integrating scattered, heterogeneous data into ML-ready training sets, discovering and selecting models from large model zoos, serving large language models straight from a database, and generating synthetic data across organisational silos without sharing raw records.'
 		},
 		{
 			id: 'Quantum Data Management',
+			kicker: 'Data Systems for Quantum Computing',
 			icon: IconAtom2,
-			blurb: 'We rethink classic data-management problems — query optimisation, entity matching, anomaly detection — for the NISQ-era quantum processor.'
+			blurb: 'We reinvent data management for the quantum era — simulating quantum circuits inside a relational database, compiling database queries to quantum primitives, and charting how data should be stored, queried, and managed on noisy intermediate-scale (NISQ) quantum processors.'
 		}
 	];
 
@@ -29,13 +26,13 @@
 	const pubFor = (id: string) => pubs.filter((p) => p.meta.pillars?.includes(id));
 </script>
 
-<Seo title="Research" description="Three research frontiers at Infinidata Lab: AI in data and model lakes, federated and private learning, and quantum data management." />
+<Seo title="Research" description="Two research directions at Infinidata Lab: data systems for AI (AI in data lakes) and data systems for quantum computing (quantum data management)." />
 
 <header class="page-head">
 	<div class="container">
 		<span class="eyebrow">What we work on</span>
 		<h1>Research</h1>
-		<p>Our work spans three connected frontiers, all asking how data should be managed when AI is the primary consumer.</p>
+		<p>Everything we build is a data system. Our research runs in two directions — making data systems work for AI, and inventing data systems for quantum computing.</p>
 	</div>
 </header>
 
@@ -48,6 +45,7 @@
 			<div class="pillar-head">
 				<div class="ic"><Icon size={26} /></div>
 				<div>
+					<span class="eyebrow">{pillar.kicker}</span>
 					<h2>{pillar.id}</h2>
 					<p>{pillar.blurb}</p>
 				</div>
@@ -102,6 +100,10 @@
 	}
 	.pillar-head p {
 		color: var(--muted);
+	}
+	.pillar-head .eyebrow {
+		display: block;
+		margin-bottom: 8px;
 	}
 	.sub {
 		font-family: var(--font-mono);

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -76,8 +76,7 @@ collections:
         multiple: true
         required: false
         options:
-          - AI in Data & Model Lakes
-          - Federated & Private Learning
+          - AI in Data Lakes
           - Quantum Data Management
       - { name: tags, label: Tags, widget: list, required: false }
       - { name: venue, label: Venue badge, widget: string, required: false, hint: 'e.g. SIGMOD 2025' }
@@ -121,8 +120,7 @@ collections:
         multiple: true
         required: false
         options:
-          - AI in Data & Model Lakes
-          - Federated & Private Learning
+          - AI in Data Lakes
           - Quantum Data Management
       - { name: award, label: Award, widget: string, required: false }
       - { name: featured, label: Featured, widget: boolean, required: false, default: false }
@@ -223,8 +221,7 @@ collections:
         multiple: true
         required: false
         options:
-          - AI in Data & Model Lakes
-          - Federated & Private Learning
+          - AI in Data Lakes
           - Quantum Data Management
       - { name: deadline, label: Application deadline, widget: datetime, required: false, format: 'YYYY-MM-DD', date_format: 'YYYY-MM-DD', time_format: false, hint: 'Leave empty for rolling / open-ended' }
       - { name: order, label: Sort order, widget: number, required: false, value_type: int }


### PR DESCRIPTION
…adges

Reframe the lab's research, populate the publications list from the PI's Google Scholar / DBLP (Amalur onward), and give venues recognizable publisher-branded badges.

Research framing — three pillars into two directions under one "data systems" theme:
  - AI in Data Lakes          (Data Systems for AI)        — absorbs the old
    "AI in Data & Model Lakes" and "Federated & Private Learning"
  - Quantum Data Management   (Data Systems for Quantum Computing)
Updates homepage, research page, footer, site description, join copy, and the
Sveltia CMS pillar options; bulk-migrates existing content frontmatter.

Publications — 31 total (8 updated + 23 new) from 2022 (Amalur) onward, with accurate authors, venues, types, and DOI/arXiv links. Adds Workshop and Preprint filter chips. Excludes off-topic outliers (physics, 6G telecom, superseded workshop papers).

Venue badges — new VenueBadge component + venue map (src/lib/venues.ts): publisher-aware, colour-coded, theme-aware badges (ACM / IEEE / VLDB / EDBT / arXiv / Springer / …) with graceful text fallback. Used by PublicationItem and ProjectCard.

Verified: type-check (no new errors), production build, and previewed the home / research / publications pages in light and dark themes.